### PR TITLE
Fix workspace protocol in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,24 @@ jobs:
           for package_dir in packages/*/; do
             if [ -f "$package_dir/package.json" ]; then
               echo "Updating version in $package_dir"
-              cd "$package_dir"
-              npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version --allow-same-version
-              cd ../..
+              node -e "
+                const fs = require('fs');
+                const path = require('path');
+                const pkgPath = path.join('$package_dir', 'package.json');
+                const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+                pkg.version = '${{ steps.get_version.outputs.VERSION }}';
+
+                // Update peerDependencies versions for @mediafox packages
+                if (pkg.peerDependencies) {
+                  for (const dep of Object.keys(pkg.peerDependencies)) {
+                    if (dep.startsWith('@mediafox/')) {
+                      pkg.peerDependencies[dep] = '^${{ steps.get_version.outputs.VERSION }}';
+                    }
+                  }
+                }
+
+                fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+              "
             fi
           done
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,14 +28,12 @@
     "packages/react": {
       "name": "@mediafox/react",
       "version": "0.9.9",
-      "dependencies": {
-        "@mediafox/core": "workspace:*",
-      },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^18.3.18",
       },
       "peerDependencies": {
+        "@mediafox/core": "^0.9.9",
         "react": ">=18.0.0",
       },
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -132,6 +132,12 @@ export default defineConfig({
   },
 
   vite: {
+    resolve: {
+      alias: {
+        "@mediafox/core": "../../packages/mediafox/src/index.ts",
+        "@mediafox/react": "../../packages/react/src/index.ts",
+      },
+    },
     worker: {
       format: "es",
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig } from "vitepress";
 
 // https://vitepress.dev/reference/site-config
@@ -134,8 +135,14 @@ export default defineConfig({
   vite: {
     resolve: {
       alias: {
-        "@mediafox/core": "../../packages/mediafox/src/index.ts",
-        "@mediafox/react": "../../packages/react/src/index.ts",
+        "@mediafox/core": path.resolve(
+          __dirname,
+          "../../packages/mediafox/src/index.ts",
+        ),
+        "@mediafox/react": path.resolve(
+          __dirname,
+          "../../packages/react/src/index.ts",
+        ),
       },
     },
     worker: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,10 +30,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@mediafox/core": "workspace:*"
-  },
   "peerDependencies": {
+    "@mediafox/core": "^0.9.9",
     "react": ">=18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Move @mediafox/core from dependencies to peerDependencies in react package
- Update publish workflow to handle peer dependencies version updates
- Add vite aliases for local development to use source files directly

## Changes
1. **packages/react/package.json**: Convert workspace dependency to peer dependency
2. **.github/workflows/publish.yml**: Replace `npm version` with Node.js JSON manipulation to avoid workspace protocol errors and update peer dependency versions
3. **docs/.vitepress/config.ts**: Add resolve aliases for local package development

## Why
The publish workflow was failing because `npm version` doesn't understand the `workspace:*` protocol. The react package should properly declare @mediafox/core as a peer dependency with matching version numbers, and during development, vite should resolve to local source files.