### PR TITLE
refactor: move mediabunny to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mediafox-monorepo",
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
+    "mediabunny": "^1.23.0",
     "typescript": "^5.7.0",
     "vitepress": "^2.0.0-alpha.12"
   },

--- a/packages/mediafox/package.json
+++ b/packages/mediafox/package.json
@@ -32,8 +32,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@webgpu/types": "^0.1.65",
-    "mediabunny": "^1.23.0"
+    "@webgpu/types": "^0.1.65"
   },
   "peerDependencies": {
     "mediabunny": "^1.23.0",


### PR DESCRIPTION
## Summary
- Moved mediabunny from `packages/mediafox/package.json` devDependencies to root `package.json` devDependencies
- Kept mediabunny as a peer dependency in the package

## Rationale
This follows best practices for monorepo dependency management by centralizing development dependencies at the root level while maintaining peer dependency declarations in individual packages.