### PR TITLE
fix: prevent frame speedup on backward seek

### DIFF
--- a/packages/mediafox/src/playback/renderer.ts
+++ b/packages/mediafox/src/playback/renderer.ts
@@ -463,7 +463,7 @@ export class VideoRenderer {
 
       // If we don't have a next frame yet, try to fetch one
       if (!this.nextFrame) {
-        void this.fetchNextFrame(timestamp);
+        void this.fetchNextFrame();
       }
     }
   }
@@ -473,7 +473,7 @@ export class VideoRenderer {
 
     // If we don't have a next frame, request one
     if (!this.nextFrame && this.frameIterator) {
-      void this.fetchNextFrame(currentTime);
+      void this.fetchNextFrame();
       return false;
     }
 
@@ -489,14 +489,14 @@ export class VideoRenderer {
       this.renderFrame(this.currentFrame);
 
       // Request the next frame asynchronously
-      void this.fetchNextFrame(currentTime);
+      void this.fetchNextFrame();
       return true;
     }
 
     return false;
   }
 
-  private async fetchNextFrame(currentTime: number): Promise<void> {
+  private async fetchNextFrame(): Promise<void> {
     if (!this.frameIterator || this.disposed) return;
 
     const currentRenderingId = this.renderingId;

--- a/packages/mediafox/src/playback/renderer.ts
+++ b/packages/mediafox/src/playback/renderer.ts
@@ -501,25 +501,16 @@ export class VideoRenderer {
 
     const currentRenderingId = this.renderingId;
 
-    // Loop until we find a frame in the future or run out of frames
-    while (true) {
-      const result = await this.frameIterator.next();
-      const frame = result.value ?? null;
+    // Get the next frame from iterator
+    const result = await this.frameIterator.next();
+    const frame = result.value ?? null;
 
-      if (!frame || currentRenderingId !== this.renderingId || this.disposed) {
-        break;
-      }
-
-      if (frame.timestamp <= currentTime) {
-        // This frame is in the past, store it and try to draw
-        this.currentFrame = frame;
-        this.renderFrame(frame);
-      } else {
-        // This frame is in the future, save it for later
-        this.nextFrame = frame;
-        break;
-      }
+    if (!frame || currentRenderingId !== this.renderingId || this.disposed) {
+      return;
     }
+
+    // Store the frame for later use
+    this.nextFrame = frame;
   }
 
   private renderFrame(frame: WrappedCanvas): void {


### PR DESCRIPTION
## Summary
- Fixed frame speedup issue when seeking backward in timeline
- Removed aggressive frame catch-up loop in renderer

## Problem
When seeking backward, frames would rapidly consume and display, creating a speedup effect. This only occurred during backward seeks, not forward seeks.

## Root Cause
The `fetchNextFrame()` method had a while loop that would keep fetching frames while `frame.timestamp <= currentTime`. After a backward seek, the audio manager would still report a slightly higher currentTime for a brief moment, causing the renderer to rapidly consume frames trying to "catch up".

## Solution
Simplified the logic to fetch one frame at a time instead of looping through multiple frames. This prevents the aggressive catch-up behavior and provides consistent playback timing regardless of seek direction.

## Test Plan
- [x] Verify backward seek no longer causes frame speedup
- [x] Verify forward seek still works correctly
- [x] Verify normal playback is unaffected