### PR TITLE
fix(compositor): update compositor worker import path and build script

### DIFF
--- a/packages/mediafox/package.json
+++ b/packages/mediafox/package.json
@@ -12,7 +12,7 @@
       "import": "./dist/index.js"
     },
     "./compositor-worker": {
-      "import": "./src/compositor/compositor-worker.ts"
+      "import": "./dist/compositor-worker.js"
     }
   },
   "files": [
@@ -22,7 +22,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build src/index.ts --outdir=dist --target=browser --format=esm --minify --external mediabunny && bun build src/compositor/compositor-worker.ts --outdir=dist --target=browser --format=esm --minify --external mediabunny",
+    "build:js": "bun build src/index.ts --outdir=dist --target=browser --format=esm --minify --external mediabunny && bun build src/compositor/compositor-worker.ts --outdir=dist --target=browser --format=esm --minify",
     "build:types": "tsc --emitDeclarationOnly",
     "test": "bun test",
     "lint": "biome lint ./src",


### PR DESCRIPTION
## Summary: Fixing the MediaFox Compositor Worker Issue

### The Problem

The `@mediafox/core` package had **two issues** causing Web Workers to fail silently:

```
Uncaught (in promise) Error: Worker error
    at worker.onerror (index.js:1:11787)
```

---

### Issue 1: Export Pointed to TypeScript Source

**Before (broken):**
```json
"./compositor-worker": {
  "import": "./src/compositor/compositor-worker.ts"  // ❌ TypeScript source
}
```

**After (fixed):**
```json
"./compositor-worker": {
  "import": "./dist/compositor-worker.js"  // ✅ Compiled JavaScript
}
```

**Why it mattered:** Web Workers cannot execute TypeScript directly. When your bundler resolved the import, it got a `.ts` file that the browser couldn't run.

---

### Issue 2: Worker Had External Dependency

**Before (broken):**
```bash
bun build src/compositor/compositor-worker.ts --external mediabunny
```

**After (fixed):**
```bash
bun build src/compositor/compositor-worker.ts  # No --external flag
```

**Why it mattered:** The `--external mediabunny` flag told the bundler "don't include mediabunny, it will be available at runtime." But Web Workers run in an **isolated context** — they can't access modules from the main thread. The worker tried to `import` mediabunny and failed because it wasn't there.

| Build | Worker Size | Result |
|-------|-------------|--------|
| With `--external` | ~26KB | ❌ Missing dependency |
| Without `--external` | ~261KB | ✅ Self-contained |

---

This revealed the recent changes to the build scripts, showing when `--external mediabunny` was added to the worker build.

---

### Final package.json Build Script

````json
{
  "scripts": {
    "build:js": "bun build src/index.ts --outdir=dist --target=browser --format=esm --minify --external mediabunny && bun build src/compositor/compositor-worker.ts --outdir=dist --target=browser --format=esm --minify"
  }
}
````

**Key insight:** The main library (`index.ts`) correctly uses `--external mediabunny` because it runs in the main thread where mediabunny is available. The worker must **bundle** mediabunny because it runs in isolation.
