### PR TITLE
feat(compositor): add per-layer fit mode

### DIFF
--- a/docs/.vitepress/components/VideoEditorPlayground.vue
+++ b/docs/.vitepress/components/VideoEditorPlayground.vue
@@ -91,6 +91,15 @@
                             <span>{{ selectedClip.rotation }}°</span>
                         </div>
                         <div class="inspector-row">
+                            <label>Fit</label>
+                            <select v-model="selectedClip.fitMode" @change="updatePreview" class="fit-select">
+                                <option value="auto">Auto (Global)</option>
+                                <option value="fill">Fill (Stretch)</option>
+                                <option value="contain">Contain (Fit)</option>
+                                <option value="cover">Cover (Zoom)</option>
+                            </select>
+                        </div>
+                        <div class="inspector-row">
                             <label>X</label>
                             <input type="number" v-model.number="selectedClip.x" step="10" @change="updatePreview" />
                         </div>
@@ -187,6 +196,7 @@ interface ClipData {
   sourceDuration: number;
   sourceOffset: number;
   volume: number;
+  fitMode: 'auto' | 'contain' | 'cover' | 'fill';
   opacity: number;
   scale: number;
   rotation: number;
@@ -255,6 +265,7 @@ const getComposition = (time: number) => {
     return {
       source: clip.source,
       sourceTime: Math.max(0, srcTime),
+      fitMode: clip.fitMode,
       transform: {
         x: clip.x,
         y: clip.y,
@@ -349,6 +360,7 @@ const loadSampleVideo = async () => {
       sourceDuration: source.duration,
       sourceOffset: 0,
       volume: 1,
+      fitMode: 'auto',
       opacity: 1,
       scale: 1,
       rotation: 0,
@@ -408,6 +420,7 @@ const handleFileSelect = async (e: Event) => {
       sourceDuration: dur,
       sourceOffset: 0,
       volume: 1,
+      fitMode: 'auto',
       opacity: 1,
       scale: 1,
       rotation: 0,

--- a/packages/mediafox/src/compositor/compositor-worker.ts
+++ b/packages/mediafox/src/compositor/compositor-worker.ts
@@ -48,6 +48,7 @@ const mapFrame = (frame: CompositorWorkerFrame): CompositionFrame => {
       source,
       sourceTime: layer.sourceTime,
       transform: layer.transform,
+      fitMode: layer.fitMode,
       visible: layer.visible,
       zIndex: layer.zIndex,
     };

--- a/packages/mediafox/src/compositor/compositor.ts
+++ b/packages/mediafox/src/compositor/compositor.ts
@@ -436,66 +436,65 @@ export class Compositor {
     const transform = layer.transform;
     const sourceWidth = layer.source.width ?? this.width;
     const sourceHeight = layer.source.height ?? this.height;
+    const hasExplicitFitMode = layer.fitMode !== undefined && layer.fitMode !== 'auto';
+    const effectiveFitMode = hasExplicitFitMode ? layer.fitMode : this.fitMode;
 
-    // Fast path: no transform object means draw with compositor fitMode
-    if (!transform) {
-      // Calculate fitted dimensions based on compositor's fitMode
-      let fittedWidth: number;
-      let fittedHeight: number;
-      let fittedX = 0;
-      let fittedY = 0;
+    let fittedWidth = sourceWidth;
+    let fittedHeight = sourceHeight;
+    let fittedX = 0;
+    let fittedY = 0;
 
-      if (sourceWidth === 0 || sourceHeight === 0) {
-        fittedWidth = this.width;
-        fittedHeight = this.height;
-      } else {
-        const sourceAspect = sourceWidth / sourceHeight;
-        const canvasAspect = this.width / this.height;
+    if (sourceWidth === 0 || sourceHeight === 0) {
+      fittedWidth = this.width;
+      fittedHeight = this.height;
+    } else {
+      const sourceAspect = sourceWidth / sourceHeight;
+      const canvasAspect = this.width / this.height;
 
-        switch (this.fitMode) {
-          case 'fill':
-            // Stretch to fill canvas - ignore aspect ratio
-            fittedWidth = this.width;
+      switch (effectiveFitMode) {
+        case 'fill':
+          // Stretch to fill canvas - ignore aspect ratio
+          fittedWidth = this.width;
+          fittedHeight = this.height;
+          break;
+
+        case 'cover':
+          // Scale to cover entire canvas - may crop
+          if (sourceAspect > canvasAspect) {
             fittedHeight = this.height;
-            break;
+            fittedWidth = this.height * sourceAspect;
+            fittedX = (this.width - fittedWidth) / 2;
+          } else {
+            fittedWidth = this.width;
+            fittedHeight = this.width / sourceAspect;
+            fittedY = (this.height - fittedHeight) / 2;
+          }
+          break;
 
-          case 'cover':
-            // Scale to cover entire canvas - may crop
-            if (sourceAspect > canvasAspect) {
-              fittedHeight = this.height;
-              fittedWidth = this.height * sourceAspect;
-              fittedX = (this.width - fittedWidth) / 2;
-            } else {
-              fittedWidth = this.width;
-              fittedHeight = this.width / sourceAspect;
-              fittedY = (this.height - fittedHeight) / 2;
-            }
-            break;
-
-          default:
-            // Scale to fit entirely within canvas - may letterbox
-            if (sourceAspect > canvasAspect) {
-              fittedWidth = this.width;
-              fittedHeight = this.width / sourceAspect;
-              fittedY = (this.height - fittedHeight) / 2;
-            } else {
-              fittedHeight = this.height;
-              fittedWidth = this.height * sourceAspect;
-              fittedX = (this.width - fittedWidth) / 2;
-            }
-            break;
-        }
+        default:
+          // Scale to fit entirely within canvas - may letterbox
+          if (sourceAspect > canvasAspect) {
+            fittedWidth = this.width;
+            fittedHeight = this.width / sourceAspect;
+            fittedY = (this.height - fittedHeight) / 2;
+          } else {
+            fittedHeight = this.height;
+            fittedWidth = this.height * sourceAspect;
+            fittedX = (this.width - fittedWidth) / 2;
+          }
+          break;
       }
+    }
 
+    if (!transform) {
       ctx.drawImage(image, fittedX, fittedY, fittedWidth, fittedHeight);
       return;
     }
 
-    // Apply layer transform without fitMode; keep intrinsic source sizing by default
-    const x = transform.x ?? 0;
-    const y = transform.y ?? 0;
-    const destWidth = transform.width ?? sourceWidth;
-    const destHeight = transform.height ?? sourceHeight;
+    const x = (transform.x ?? 0) + fittedX;
+    const y = (transform.y ?? 0) + fittedY;
+    const destWidth = transform.width ?? fittedWidth;
+    const destHeight = transform.height ?? fittedHeight;
     const rotation = transform.rotation ?? 0;
     const scaleX = transform.scaleX ?? 1;
     const scaleY = transform.scaleY ?? 1;
@@ -607,6 +606,7 @@ export class Compositor {
         sourceId,
         sourceTime: layer.sourceTime,
         transform: layer.transform,
+        fitMode: layer.fitMode,
         visible: layer.visible,
         zIndex: layer.zIndex,
       };

--- a/packages/mediafox/src/compositor/index.ts
+++ b/packages/mediafox/src/compositor/index.ts
@@ -13,6 +13,7 @@ export type {
   CompositorSourceOptions,
   CompositorWorkerOptions,
   FitMode,
+  LayerFitMode,
   FrameExportOptions,
   LayerTransform,
   PreviewOptions,

--- a/packages/mediafox/src/compositor/types.ts
+++ b/packages/mediafox/src/compositor/types.ts
@@ -9,6 +9,7 @@ export type CompositorRendererType = RendererType;
  * - `'cover'`: Scale to completely cover the canvas, preserving aspect ratio. Parts may be cropped.
  */
 export type FitMode = 'contain' | 'cover' | 'fill';
+export type LayerFitMode = FitMode | 'auto';
 
 export interface CompositorOptions {
   canvas: HTMLCanvasElement | OffscreenCanvas;
@@ -39,6 +40,11 @@ export interface CompositorLayer {
   source: CompositorSource;
   sourceTime?: number;
   transform?: LayerTransform;
+  /**
+   * Fit mode override for this layer. Use 'auto' or leave undefined to use the
+   * compositor's global fitMode.
+   */
+  fitMode?: LayerFitMode;
   visible?: boolean;
   zIndex?: number;
 }

--- a/packages/mediafox/src/compositor/worker-types.ts
+++ b/packages/mediafox/src/compositor/worker-types.ts
@@ -1,10 +1,11 @@
 import type { MediaSource } from '../types';
-import type { CompositorSourceOptions, FrameExportOptions, LayerTransform, SourceType } from './types';
+import type { CompositorSourceOptions, FrameExportOptions, LayerFitMode, LayerTransform, SourceType } from './types';
 
 export interface CompositorWorkerLayer {
   sourceId: string;
   sourceTime?: number;
   transform?: LayerTransform;
+  fitMode?: LayerFitMode;
   visible?: boolean;
   zIndex?: number;
 }

--- a/packages/mediafox/src/index.ts
+++ b/packages/mediafox/src/index.ts
@@ -27,6 +27,7 @@ export type {
   CompositorSourceOptions,
   CompositorWorkerOptions,
   FitMode,
+  LayerFitMode,
   FrameExportOptions,
   LayerTransform,
   PreviewOptions,


### PR DESCRIPTION
Adds per-layer fit mode support (auto inherits global fit mode) and exposes it in the playground inspector. Global fit mode remains the default when a layer's fit mode is auto/undefined.