### PR TITLE
feat(compositor): add text support with customizable properties

### DIFF
--- a/docs/api/compositor.md
+++ b/docs/api/compositor.md
@@ -131,6 +131,45 @@ async loadImage(source: string | Blob | File): Promise<CompositorSource>
 const image = await compositor.loadImage('https://example.com/overlay.png');
 ```
 
+### `loadText(options, sourceOptions?)`
+
+Creates a text source and adds it to the compositor's source pool. Text sources behave like image layers but are dynamically rendered.
+
+<div class="method-signature">
+
+```typescript
+loadText(
+  options: TextSourceOptions,
+  sourceOptions?: CompositorSourceOptions
+): CompositorTextSource
+```
+
+</div>
+
+**Parameters:**
+- `options`: Text content and styling configuration
+- `sourceOptions`: Optional source ID and duration
+
+**Returns:** The loaded text source (can be updated later)
+
+**Example:**
+
+```typescript
+const title = compositor.loadText({
+  text: 'Hello World',
+  fontSize: 64,
+  color: '#ffffff',
+  fontWeight: 'bold',
+  shadow: { color: 'rgba(0,0,0,0.5)', blur: 4, offsetY: 2 }
+});
+
+// Update text later
+title.update({
+  text: 'New Text',
+  style: { color: '#ff0000' }
+});
+```
+
 ### `loadAudio(source, options?)`
 
 Loads an audio source into the compositor's source pool.
@@ -621,11 +660,73 @@ A loaded media source.
 ```typescript
 interface CompositorSource {
   id: string;
-  type: 'video' | 'image' | 'audio';
+  type: 'video' | 'image' | 'audio' | 'text';
   duration: number;
   width?: number;
   height?: number;
   getFrameAt(time: number): Promise<CanvasImageSource | null>;
+}
+```
+
+### CompositorTextSource
+
+A specialized source for text content.
+
+```typescript
+interface CompositorTextSource extends CompositorSource {
+  readonly type: 'text';
+  update(changes: TextSourceUpdate): void;
+  getOptions(): TextSourceOptions;
+}
+```
+
+### TextSourceOptions
+
+Configuration for text sources.
+
+```typescript
+interface TextSourceOptions {
+  text: string;              // Content to render
+  fontFamily?: string;       // Default: 'sans-serif'
+  fontSize?: number;         // Default: 48
+  fontWeight?: string;       // 'normal', 'bold', etc.
+  fontStyle?: string;        // 'normal', 'italic'
+  color?: string;            // Fill color (default: '#ffffff')
+  align?: 'left' | 'center' | 'right';
+  lineHeight?: number;       // Default: 1.2
+  letterSpacing?: number;    // Default: 0
+  maxWidth?: number;         // Wrap width
+  padding?: number;          // Padding around text (default: 8)
+
+  shadow?: {
+    color?: string;
+    offsetX?: number;
+    offsetY?: number;
+    blur?: number;
+  };
+
+  stroke?: {
+    color?: string;
+    width?: number;
+  };
+
+  background?: {
+    color?: string;
+    paddingX?: number;
+    paddingY?: number;
+    borderRadius?: number;
+  };
+}
+```
+
+### TextSourceUpdate
+
+Options for updating an existing text source.
+
+```typescript
+interface TextSourceUpdate {
+  text?: string;
+  style?: Partial<Omit<TextSourceOptions, 'text'>>;
 }
 ```
 

--- a/docs/guide/compositor.md
+++ b/docs/guide/compositor.md
@@ -45,6 +45,16 @@ const music = await compositor.loadAudio('soundtrack.mp3');
 
 // Load from file input
 const fileVideo = await compositor.loadSource(fileInput.files[0]);
+
+// Create a text source
+const title = compositor.loadText({
+  text: 'My Video',
+  fontSize: 120,
+  fontFamily: 'Inter',
+  fontWeight: 'bold',
+  color: '#ffffff',
+  shadow: { color: 'black', blur: 10, offsetY: 5 }
+});
 ```
 
 ## Rendering Frames

--- a/packages/mediafox/src/compositor/index.ts
+++ b/packages/mediafox/src/compositor/index.ts
@@ -11,6 +11,7 @@ export type {
   CompositorRendererType,
   CompositorSource,
   CompositorSourceOptions,
+  CompositorTextSource,
   CompositorWorkerOptions,
   FitMode,
   FrameExportOptions,
@@ -18,4 +19,9 @@ export type {
   LayerTransform,
   PreviewOptions,
   SourceType,
+  TextBackgroundOptions,
+  TextShadowOptions,
+  TextSourceOptions,
+  TextSourceUpdate,
+  TextStrokeOptions,
 } from './types';

--- a/packages/mediafox/src/compositor/types.ts
+++ b/packages/mediafox/src/compositor/types.ts
@@ -85,7 +85,7 @@ export interface FrameExportOptions {
   quality?: number;
 }
 
-export type SourceType = 'video' | 'image' | 'audio';
+export type SourceType = 'video' | 'image' | 'audio' | 'text';
 
 export interface CompositorSource {
   id: string;
@@ -103,6 +103,100 @@ export interface CompositorSourceOptions {
   id?: string;
   startTime?: number;
   endTime?: number;
+}
+
+// ── Text Source Types ──────────────────────────────────────────────────
+
+export interface TextShadowOptions {
+  color?: string;
+  offsetX?: number;
+  offsetY?: number;
+  blur?: number;
+}
+
+export interface TextStrokeOptions {
+  color?: string;
+  width?: number;
+}
+
+export interface TextBackgroundOptions {
+  color?: string;
+  paddingX?: number;
+  paddingY?: number;
+  borderRadius?: number;
+}
+
+export interface TextSourceOptions {
+  /** The text content to render. Supports newlines (\n). */
+  text: string;
+  /** CSS font family. Defaults to 'sans-serif'. */
+  fontFamily?: string;
+  /** Font size in pixels. Defaults to 48. */
+  fontSize?: number;
+  /** Font weight (e.g. 'normal', 'bold', '700'). Defaults to 'normal'. */
+  fontWeight?: string;
+  /** Font style (e.g. 'normal', 'italic'). Defaults to 'normal'. */
+  fontStyle?: string;
+  /** Text fill color. Defaults to '#ffffff'. */
+  color?: string;
+  /** Text alignment within the bounding box. Defaults to 'left'. */
+  align?: 'left' | 'center' | 'right';
+  /** Line height multiplier (e.g. 1.2). Defaults to 1.2. */
+  lineHeight?: number;
+  /** Letter spacing in pixels. Defaults to 0. */
+  letterSpacing?: number;
+  /** Drop shadow behind text. */
+  shadow?: TextShadowOptions;
+  /** Text outline / stroke. */
+  stroke?: TextStrokeOptions;
+  /** Background behind the text bounding box. */
+  background?: TextBackgroundOptions;
+  /**
+   * Maximum width in pixels before text wraps. When unset, the text is
+   * rendered as a single line per explicit newline.
+   */
+  maxWidth?: number;
+  /**
+   * Padding in pixels added around the rendered text bitmap.
+   * Prevents clipping of shadows, strokes, and descenders. Defaults to 8.
+   */
+  padding?: number;
+  /**
+   * Escape hatch: apply arbitrary CanvasRenderingContext2D properties before
+   * drawing. Runs after all built-in styling is applied, giving full control
+   * over any canvas text property the API doesn't expose directly.
+   *
+   * @example
+   * ```ts
+   * canvasOverrides: (ctx) => {
+   *   ctx.textBaseline = 'top';
+   *   ctx.direction = 'rtl';
+   * }
+   * ```
+   *
+   * NOTE: This callback is **not serialisable** and will be ignored in worker
+   * mode. For worker-safe styling, use the declarative properties.
+   */
+  canvasOverrides?: (ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D) => void;
+}
+
+export interface TextSourceUpdate {
+  /** Replace the text content. */
+  text?: string;
+  /** Partial style overrides — merged with existing options. */
+  style?: Partial<Omit<TextSourceOptions, 'text'>>;
+}
+
+/**
+ * Extended source interface returned by `loadText()`. Provides methods
+ * to update text content and styling after creation.
+ */
+export interface CompositorTextSource extends CompositorSource {
+  readonly type: 'text';
+  /** Replace text content and/or merge style overrides, then re-render the bitmap. */
+  update(changes: TextSourceUpdate): void;
+  /** Returns a snapshot of the current text options. */
+  getOptions(): TextSourceOptions;
 }
 
 export type CompositorEventMap = {

--- a/packages/mediafox/src/compositor/worker-types.ts
+++ b/packages/mediafox/src/compositor/worker-types.ts
@@ -1,5 +1,13 @@
 import type { MediaSource } from '../types';
-import type { CompositorSourceOptions, FrameExportOptions, LayerFitMode, LayerTransform, SourceType } from './types';
+import type {
+  CompositorSourceOptions,
+  FrameExportOptions,
+  LayerFitMode,
+  LayerTransform,
+  SourceType,
+  TextSourceOptions,
+  TextSourceUpdate,
+} from './types';
 
 export interface CompositorWorkerLayer {
   sourceId: string;
@@ -66,4 +74,16 @@ export interface CompositorWorkerResizePayload {
 export interface CompositorWorkerExportPayload {
   frame: CompositorWorkerFrame;
   options?: FrameExportOptions;
+}
+
+export interface CompositorWorkerLoadTextPayload {
+  options: Omit<TextSourceOptions, 'canvasOverrides'>;
+  sourceOptions?: CompositorSourceOptions;
+}
+
+export interface CompositorWorkerUpdateTextPayload {
+  id: string;
+  changes: Omit<TextSourceUpdate, 'style'> & {
+    style?: Partial<Omit<TextSourceOptions, 'text' | 'canvasOverrides'>>;
+  };
 }

--- a/packages/mediafox/src/index.ts
+++ b/packages/mediafox/src/index.ts
@@ -25,6 +25,7 @@ export type {
   CompositorRendererType,
   CompositorSource,
   CompositorSourceOptions,
+  CompositorTextSource,
   CompositorWorkerOptions,
   FitMode,
   FrameExportOptions,
@@ -32,6 +33,11 @@ export type {
   LayerTransform,
   PreviewOptions,
   SourceType,
+  TextBackgroundOptions,
+  TextShadowOptions,
+  TextSourceOptions,
+  TextSourceUpdate,
+  TextStrokeOptions,
 } from './compositor';
 // Compositor
 export { Compositor, SourcePool } from './compositor';


### PR DESCRIPTION

https://github.com/user-attachments/assets/ef213f89-8f86-4546-b8e5-c7e768dc81b6

This pull request adds support for text layers to the `VideoEditorPlayground` component and documents the new text source API for the compositor. Users can now add, edit, and style text clips directly in the video editor interface, and the API documentation has been updated to reflect the new capabilities for working with text sources.

**Video Editor Playground Enhancements:**

* Added a "+ Add Text" button to allow users to insert text clips into the timeline (`VideoEditorPlayground.vue`).
* Implemented a dedicated text track in the timeline UI, with visual styling for text clips (`VideoEditorPlayground.vue`). [[1]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R280-R301) [[2]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R1440-R1472)
* Enabled editing of text properties (content, font, size, weight, color, alignment, shadow, stroke, background, etc.) in the inspector panel when a text clip is selected (`VideoEditorPlayground.vue`). [[1]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R96-R170) [[2]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R361-R373)
* Updated the composition logic to render text clips as layers on top of video/image layers (`VideoEditorPlayground.vue`). [[1]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179L330-R451) [[2]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179L350-R485)
* Added logic to create and update text sources using the compositor's new API, and to store text-specific properties in the clip data (`VideoEditorPlayground.vue`).

**API and Documentation Updates:**

* Documented the new `loadText` method, `CompositorTextSource` interface, and text source options in the compositor API reference (`compositor.md`). [[1]](diffhunk://#diff-3c45fae1045af3cfc00e18def78c728d8877d9092a25350329e5adfc2c3fd148R134-R172) [[2]](diffhunk://#diff-3c45fae1045af3cfc00e18def78c728d8877d9092a25350329e5adfc2c3fd148L624-R732)
* Added usage examples for creating and updating text sources in the compositor guide (`compositor.md`, `guide/compositor.md`).

**Other Improvements:**

* Adjusted track assignment logic to account for text clips, ensuring video/image tracks are not affected by text layers (`VideoEditorPlayground.vue`). [[1]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179L420-R555) [[2]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179L481-R698)
* Increased the timeline height and improved inspector panel scrolling for better usability with additional controls (`VideoEditorPlayground.vue`). [[1]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R1232-R1234) [[2]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179R1249-R1250) [[3]](diffhunk://#diff-a2e9819aa6780bb63452f188678e0876a6b67ea7fb23b4c80c69c561bd368179L1117-R1334)
* Updated type imports to include `CompositorTextSource` in preparation for worker support (`compositor-worker.ts`).